### PR TITLE
feat(derive): add attribute `#[thisctx(visibility)]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🎈 thisctx
 
-A simple crate work with [thiserror](https://crates.io/crates/thiserror) to
+A simple crate works with [thiserror](https://crates.io/crates/thiserror) to
 create errors with contexts, inspired by
 [snafu](https://crates.io/crates/snafu).
 

--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -60,7 +60,7 @@ impl<'a> Enum<'a> {
         let variants = data
             .variants
             .iter()
-            .map(|node| Variant::from_syn(node))
+            .map(Variant::from_syn)
             .collect::<Result<_>>()?;
         Ok(Enum {
             original: node,
@@ -86,7 +86,7 @@ impl<'a> Field<'a> {
     fn from_syn_many(fields: &'a Fields) -> Result<Vec<Self>> {
         let mut fields = fields
             .iter()
-            .map(|field| Field::from_syn(field))
+            .map(Field::from_syn)
             .collect::<Result<Vec<_>>>()?;
         find_source_field(&mut fields);
         Ok(fields)

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -1,16 +1,34 @@
-use syn::{parse::Nothing, Attribute, Error, Result};
+use syn::{
+    parenthesized,
+    parse::{Nothing, ParseStream},
+    token, Attribute, Error, Result, Token, Visibility,
+};
+
+mod kw {
+    use syn::custom_keyword;
+
+    custom_keyword!(visibility);
+}
 
 #[derive(Default)]
 pub struct Attrs<'a> {
+    pub thisctx: Thisctx,
     pub source: Option<&'a Attribute>,
     pub is_source: bool,
+}
+
+#[derive(Default)]
+pub struct Thisctx {
+    pub vis: Option<Visibility>,
 }
 
 pub fn get(input: &[Attribute]) -> Result<Attrs> {
     let mut attrs = Attrs::default();
 
     for attr in input {
-        if attr.path.is_ident("source") {
+        if attr.path.is_ident("thisctx") {
+            parse_thisctx_attribute(&mut attrs.thisctx, attr)?;
+        } else if attr.path.is_ident("source") {
             if attrs.source.is_some() {
                 require_empty_attribute(attr)?;
                 return Err(Error::new_spanned(attr, "duplicate #[source] attribute"));
@@ -25,4 +43,36 @@ pub fn get(input: &[Attribute]) -> Result<Attrs> {
 fn require_empty_attribute(attr: &Attribute) -> Result<()> {
     syn::parse2::<Nothing>(attr.tokens.clone())?;
     Ok(())
+}
+
+fn parse_thisctx_attribute(attrs: &mut Thisctx, attr: &Attribute) -> Result<()> {
+    attr.parse_args_with(|input: ParseStream| {
+        loop {
+            if input.is_empty() {
+                break;
+            }
+            let lookhead = input.lookahead1();
+            if lookhead.peek(kw::visibility) {
+                let kw = input.parse::<kw::visibility>()?;
+                if attrs.vis.is_some() {
+                    return Err(Error::new_spanned(
+                        kw,
+                        "duplicate #[thisctx(visibility)] attribute",
+                    ));
+                }
+                if input.peek(token::Paren) {
+                    let content;
+                    parenthesized!(content in input);
+                    attrs.vis = Some(content.parse()?);
+                }
+            } else {
+                return Err(lookhead.error());
+            }
+            if input.is_empty() {
+                break;
+            }
+            input.parse::<Token![,]>()?;
+        }
+        Ok(())
+    })
 }

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -17,7 +17,12 @@ pub fn impl_struct(input: Struct) -> TokenStream {
     let error = &input.original.ident;
     Context {
         error,
-        vis: &input.original.vis,
+        vis: input
+            .attrs
+            .thisctx
+            .vis
+            .as_ref()
+            .unwrap_or(&input.original.vis),
         ident: error,
         fields: &input.fields,
         original_fields: &input.data.fields,
@@ -39,7 +44,13 @@ impl<'a> Enum<'a> {
         let ident = &input.original.ident;
         Context {
             error,
-            vis: &self.original.vis,
+            vis: input
+                .attrs
+                .thisctx
+                .vis
+                .as_ref()
+                .or(self.attrs.thisctx.vis.as_ref())
+                .unwrap_or(&self.original.vis),
             ident,
             fields: &input.fields,
             original_fields: &input.original.fields,

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -7,7 +7,7 @@ mod expand;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[proc_macro_derive(WithContext, attributes(source))]
+#[proc_macro_derive(WithContext, attributes(source, thisctx))]
 pub fn derive_with_context(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     expand::derive(&input)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 type BoxError = Box<dyn std::error::Error>;
 
 #[derive(Debug, Error, WithContext)]
-enum ErrorEnum {
+pub enum ErrorEnum {
     #[error("{context_1}{source}{context_2}")]
     NamedWithSource {
         context_1: String,
@@ -37,7 +37,7 @@ enum ErrorEnum {
 
 #[derive(Debug, Error, WithContext)]
 #[error("{context_1}{source}{context_2}")]
-struct ErrorStruct {
+pub struct ErrorStruct {
     context_1: String,
     source: BoxError,
     context_2: String,

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -1,0 +1,9 @@
+use thisctx::WithContext;
+
+#[derive(WithContext)]
+#[thisctx(visibility(pub(crate)))]
+pub enum Error {
+    #[thisctx(visibility(pub))]
+    PubVariant,
+    PubCrateVariant,
+}


### PR DESCRIPTION
Allows using `#[thisctx(visibility)]` attribute to change the visibility of generated context types.