### PR TITLE
feat(derive): generate extra traits and methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "impl",
     "tests/derive_enum.rs",
     "tests/derive_struct.rs",
+    "tests/extra_traits.rs",
     "tests/suffix.rs",
     "tests/visibility.rs",
 ]

--- a/tests/extra_traits.rs
+++ b/tests/extra_traits.rs
@@ -1,0 +1,16 @@
+use thisctx::WithContext;
+
+#[derive(Debug, WithContext)]
+enum Error {
+    ErrorFromContext(String),
+    IntoError(#[source] String),
+}
+
+fn requires_error(_: Error) {}
+
+#[test]
+fn into_error() {
+    requires_error(ErrorFromContextContext("").into());
+    requires_error(ErrorFromContextContext("").into_error(()));
+    requires_error(IntoErrorContext().into_error("".to_owned()));
+}


### PR DESCRIPTION
Generates extra traits and methods for context types:

- `into_error()` is added to all context types
- If `Context` doesn't define a `source` field, `From<Context>` is implemented for its associated error type.