### PR TITLE
feat(derive): auto generate unit structs for empty contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "tests/derive_struct.rs",
     "tests/extra_traits.rs",
     "tests/suffix.rs",
+    "tests/unit.rs",
     "tests/visibility.rs",
 ]
 

--- a/tests/derive_enum.rs
+++ b/tests/derive_enum.rs
@@ -53,9 +53,9 @@ fn with_context() {
         context_2: 0,
     })
     .unwrap();
-    true.context(EmptyNamedContext {}).unwrap();
+    true.context(EmptyNamedContext).unwrap();
     ok().context(UnnamedWithSourceContext("", 0)).unwrap();
     true.context(UnnamedWithoutSourceContext("", 0)).unwrap();
-    true.context(EmptyUnnamedContext()).unwrap();
+    true.context(EmptyUnnamedContext).unwrap();
     true.context(UnitContext).unwrap();
 }

--- a/tests/derive_struct.rs
+++ b/tests/derive_struct.rs
@@ -68,9 +68,9 @@ fn with_context() {
         context_2: 0,
     })
     .unwrap();
-    true.context(EmptyNamedContext {}).unwrap();
+    true.context(EmptyNamedContext).unwrap();
     ok().context(UnnamedWithSourceContext("", 0)).unwrap();
     true.context(UnnamedWithoutSourceContext("", 0)).unwrap();
-    true.context(EmptyUnnamedContext()).unwrap();
+    true.context(EmptyUnnamedContext).unwrap();
     true.context(UnitContext).unwrap();
 }

--- a/tests/extra_traits.rs
+++ b/tests/extra_traits.rs
@@ -12,5 +12,5 @@ fn requires_error(_: Error) {}
 fn into_error() {
     requires_error(ErrorFromContextContext("").into());
     requires_error(ErrorFromContextContext("").into_error(()));
-    requires_error(IntoErrorContext().into_error("".to_owned()));
+    requires_error(IntoErrorContext.into_error("".to_owned()));
 }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -1,0 +1,15 @@
+use thisctx::WithContext;
+
+#[derive(Debug, WithContext)]
+#[thisctx(unit(true))]
+enum Error {
+    #[thisctx(unit(false))]
+    NotUnit(),
+    Unit(),
+}
+
+#[test]
+fn with_context() {
+    true.context(NotUnitContext()).unwrap();
+    true.context(UnitContext).unwrap();
+}


### PR DESCRIPTION
Automatically generates unit struct when a context type is empty, this can be turn off by specifying `#[thisctx(unit(false))]`.