### PR TITLE
feat(derive): support add extra attributes to generated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "impl",
+    "tests/attr.rs",
     "tests/derive_enum.rs",
     "tests/derive_struct.rs",
     "tests/extra_traits.rs",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ fn load_config(path: &Path) -> Result<String, Error> {
 - [x] Switch to Rust 2021.
 - [x] Use derive macro instead.
 - [ ] Support generics.
+- [ ] Add attributes to context types.
 
 ## ⚖️ License
 

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -1,3 +1,4 @@
+use proc_macro2::TokenStream;
 use syn::{
     parenthesized,
     parse::{Nothing, Parse, ParseStream},
@@ -10,6 +11,7 @@ mod kw {
     custom_keyword!(visibility);
     custom_keyword!(suffix);
     custom_keyword!(unit);
+    custom_keyword!(attr);
 }
 
 #[derive(Default)]
@@ -24,6 +26,7 @@ pub struct Thisctx {
     pub visibility: Option<Visibility>,
     pub suffix: Option<Suffix>,
     pub unit: Option<bool>,
+    pub attr: Vec<TokenStream>,
 }
 
 pub enum Suffix {
@@ -97,6 +100,9 @@ fn parse_thisctx_attribute(attrs: &mut Thisctx, attr: &Attribute) -> Result<()> 
             } else if lookhead.peek(kw::unit) {
                 check_dup!(unit);
                 attrs.unit = parse_thisctx_arg::<LitBool>(input)?.map(|flag| flag.value);
+            } else if lookhead.peek(kw::attr) {
+                input.parse::<kw::attr>()?;
+                attrs.attr.extend(parse_thisctx_arg(input)?);
             } else {
                 return Err(lookhead.error());
             }

--- a/tests/attr.rs
+++ b/tests/attr.rs
@@ -1,0 +1,20 @@
+use thisctx::WithContext;
+
+#[derive(WithContext)]
+#[thisctx(attr(doc = "I'm on Line#2\n\n"))]
+#[thisctx(attr(derive(Clone)))]
+pub enum Error {
+    #[thisctx(attr(doc = "I'm on Line#1\n\n"))]
+    #[thisctx(attr(derive(Copy)))]
+    ExtendAttributes(String),
+    #[thisctx(attr(doc = "I'm also on Line#1\n\n"))]
+    FieldAttributes(#[thisctx(attr(doc = "I'm a field"))] String),
+}
+
+fn requires_copied<T: Copy>(_: T) {}
+
+#[test]
+fn copy_context() {
+    let ctx = ExtendAttributesContext("What's going on?");
+    requires_copied(ctx);
+}


### PR DESCRIPTION
Supports add extra attributes to generated types using `#[thisctx[attr]`.

## Example

```rust
#[derive(WithContext)]
#[thisctx(attr(derive(Debug, Clone, Copy)))]
enum Error {
    Variant1(String),
}
```