### PR TITLE
feat(derive): support generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,5 @@
 [workspace]
-members = [
-    "impl",
-    "tests/attr.rs",
-    "tests/derive_enum.rs",
-    "tests/derive_struct.rs",
-    "tests/enum_into.rs",
-    "tests/extra_traits.rs",
-    "tests/struct_into.rs",
-    "tests/suffix.rs",
-    "tests/unit.rs",
-    "tests/visibility.rs",
-]
+members = ["impl"]
 
 [package]
 name = "thisctx"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fn load_config(path: &Path) -> Result<String, Error> {
 - [x] Use derive macro instead.
 - [x] Add attributes to context types.
 - [x] Support transparent error.
-- [ ] Support generics.
+- [x] Support generics.
 
 ## ⚖️ License
 

--- a/impl/src/ast.rs
+++ b/impl/src/ast.rs
@@ -84,12 +84,7 @@ impl<'a> Variant<'a> {
 
 impl<'a> Field<'a> {
     fn from_syn_many(fields: &'a Fields) -> Result<Vec<Self>> {
-        let mut fields = fields
-            .iter()
-            .map(Field::from_syn)
-            .collect::<Result<Vec<_>>>()?;
-        find_source_field(&mut fields);
-        Ok(fields)
+        fields.iter().map(Field::from_syn).collect()
     }
 
     fn from_syn(node: &'a syn::Field) -> Result<Self> {
@@ -97,27 +92,5 @@ impl<'a> Field<'a> {
             original: node,
             attrs: attr::get(&node.attrs)?,
         })
-    }
-
-    pub fn is_source(&self) -> bool {
-        self.attrs.is_source
-    }
-}
-
-fn find_source_field(fields: &mut [Field]) {
-    for field in fields.iter_mut() {
-        if field.attrs.source.is_some() {
-            field.attrs.is_source = true;
-            return;
-        }
-    }
-    for field in fields.iter_mut() {
-        match &field.original.ident {
-            Some(ident) if ident == "source" => {
-                field.attrs.is_source = true;
-                return;
-            }
-            _ => (),
-        }
     }
 }

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -29,7 +29,7 @@ pub struct AttrThisctx {
     pub suffix: Option<Suffix>,
     pub unit: Option<bool>,
     pub attr: Vec<TokenStream>,
-    pub into: Option<Type>,
+    pub into: Vec<Type>,
 }
 
 #[derive(Default)]
@@ -123,8 +123,8 @@ fn parse_thisctx_attribute(attrs: &mut AttrThisctx, attr: &Attribute) -> Result<
                 input.parse::<kw::attr>()?;
                 attrs.attr.extend(parse_thisctx_arg(input)?);
             } else if lookhead.peek(kw::into) {
-                check_dup!(into);
-                attrs.into = parse_thisctx_arg(input)?;
+                input.parse::<kw::into>()?;
+                attrs.into.extend(parse_thisctx_arg(input)?);
             } else {
                 return Err(lookhead.error());
             }

--- a/impl/src/attr.rs
+++ b/impl/src/attr.rs
@@ -21,7 +21,6 @@ pub struct Attrs<'a> {
     pub thisctx: AttrThisctx,
     pub source: Option<&'a Attribute>,
     pub error: Option<AttrError<'a>>,
-    pub is_source: bool,
 }
 
 #[derive(Default)]

--- a/impl/src/expand.rs
+++ b/impl/src/expand.rs
@@ -1,12 +1,23 @@
 use crate::{
     ast::{Enum, Field, Input, Struct, Variant},
     attr::{Attrs, Suffix},
+    generics::{GenericName, TypeParamBound},
 };
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
-use syn::{punctuated::Punctuated, DeriveInput, Fields, Ident, Member, Result, Token, Visibility};
+use syn::{token, DeriveInput, Fields, Ident, Index, Result, Token, Type, Visibility};
+
+type GenericsAnalyzer<'a> = crate::generics::GenericsAnalyzer<'a, GenericBoundsContext>;
+type GenericBounds<'a> = crate::generics::GenericBounds<'a, GenericBoundsContext>;
 
 const DEFAULT_SUFFIX: &str = "Context";
+
+macro_rules! quote_extend {
+    ($tokens:ident=> $($tt:tt)*) => {{
+        let mut _s = &mut *$tokens;
+        ::quote::quote_each_token!(_s $($tt)*);
+    }};
+}
 
 pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
     let input = Input::from_syn(node)?;
@@ -17,36 +28,19 @@ pub fn derive(node: &DeriveInput) -> Result<TokenStream> {
 }
 
 pub fn impl_struct(input: Struct) -> Option<TokenStream> {
-    macro_rules! attr {
-        ($ident:ident) => {{
-            input.attrs.thisctx.$ident.as_ref()
-        }};
-    }
     if input.attrs.is_transparent() {
         return None;
     }
-
-    let ident = &input.original.ident;
-    let error = input
-        .attrs
-        .thisctx
-        .into
-        .as_ref()
-        .map(<_>::to_token_stream)
-        .unwrap_or_else(|| ident.to_token_stream());
-    let attr = quote_attr(input.attrs.thisctx.attr.iter());
     Some(
         Context {
-            error: &error,
-            vis: attr!(visibility).unwrap_or(&input.original.vis),
-            ident,
-            suffix: attr!(suffix),
+            input: input.original,
+            variant: None,
+            surround: Surround::from_fields(&input.data.fields),
+            options: ContextOptions::from_attrs([&input.attrs].into_iter()),
+            ident: &input.original.ident,
             fields: &input.fields,
-            original_fields: &input.data.fields,
-            unit: attr!(unit).copied(),
-            attr: &attr,
         }
-        .impl_into_error(quote!(#ident)),
+        .impl_all(),
     )
 }
 
@@ -54,55 +48,25 @@ pub fn impl_enum(input: Enum) -> TokenStream {
     input
         .variants
         .iter()
-        .map(|variant| input.impl_variant(variant).to_token_stream())
+        .flat_map(|variant| input.impl_variant(variant))
         .collect()
 }
 
 impl<'a> Enum<'a> {
     fn impl_variant(&self, input: &Variant) -> Option<TokenStream> {
-        macro_rules! attr {
-            ($ident:ident) => {{
-                input
-                    .attrs
-                    .thisctx
-                    .$ident
-                    .as_ref()
-                    .or(self.attrs.thisctx.$ident.as_ref())
-            }};
-        }
         if input.attrs.is_transparent() {
             return None;
         }
-
-        let enum_ident = &self.original.ident;
-        let ident = &input.original.ident;
-        let error = self
-            .attrs
-            .thisctx
-            .into
-            .as_ref()
-            .map(<_>::to_token_stream)
-            .unwrap_or_else(|| enum_ident.to_token_stream());
-        let attr = quote_attr(
-            input
-                .attrs
-                .thisctx
-                .attr
-                .iter()
-                .chain(self.attrs.thisctx.attr.iter()),
-        );
         Some(
             Context {
-                error: &error,
-                vis: attr!(visibility).unwrap_or(&self.original.vis),
-                ident,
-                suffix: attr!(suffix),
+                input: self.original,
+                variant: Some(&input.original.ident),
+                surround: Surround::from_fields(&input.original.fields),
+                options: ContextOptions::from_attrs([&self.attrs, &input.attrs].into_iter()),
+                ident: &input.original.ident,
                 fields: &input.fields,
-                original_fields: &input.original.fields,
-                unit: attr!(unit).copied(),
-                attr: &attr,
             }
-            .impl_into_error(quote!(#enum_ident::#ident)),
+            .impl_all(),
         )
     }
 }
@@ -116,156 +80,486 @@ impl<'a> Attrs<'a> {
     }
 }
 
-fn find_source_field(fields: &[Field]) -> usize {
-    for (i, field) in fields.iter().enumerate() {
-        if field.attrs.source.is_some() {
-            return i;
-        }
-    }
-    for (i, field) in fields.iter().enumerate() {
-        match &field.original.ident {
-            Some(ident) if ident == "source" => {
-                return i;
-            }
-            _ => (),
-        }
-    }
-    fields.len()
-}
-
 struct Context<'a> {
-    error: &'a TokenStream,
-    vis: &'a Visibility,
+    input: &'a DeriveInput,
+    variant: Option<&'a Ident>,
+    surround: Surround,
+    options: ContextOptions<'a>,
     ident: &'a Ident,
-    suffix: Option<&'a Suffix>,
     fields: &'a [Field<'a>],
-    original_fields: &'a Fields,
-    unit: Option<bool>,
-    attr: &'a TokenStream,
 }
 
-fn quote_attr<'a>(attrs: impl IntoIterator<Item = &'a TokenStream>) -> TokenStream {
-    attrs.into_iter().map(|tokens| quote!(#[#tokens])).collect()
+#[derive(Default)]
+struct ContextOptions<'a> {
+    visibility: Option<&'a Visibility>,
+    suffix: Option<&'a Suffix>,
+    unit: Option<bool>,
+    into: Option<&'a Type>,
+    attr: TokenStream,
+}
+
+#[derive(Default)]
+struct GenericBoundsContext {
+    selected: bool,
+}
+
+impl<'a> ContextOptions<'a> {
+    fn from_attrs(attrs_iter: impl DoubleEndedIterator<Item = &'a Attrs<'a>> + Clone) -> Self {
+        let mut new = ContextOptions::default();
+
+        macro_rules! update_options {
+            ($attrs:ident, $($attr:ident),*) => {
+                $(if let Some(attr) = $attrs.thisctx.$attr.as_ref() {
+                    new.$attr = Some(attr);
+                })*
+            };
+        }
+
+        for attrs in attrs_iter.clone().rev() {
+            QuoteAttrs(&attrs.thisctx.attr).to_tokens(&mut new.attr);
+        }
+
+        for attrs in attrs_iter {
+            update_options!(attrs, visibility, suffix, into);
+            if let Some(unit) = attrs.thisctx.unit {
+                new.unit = Some(unit);
+            }
+        }
+
+        new
+    }
 }
 
 impl<'a> Context<'a> {
-    fn impl_into_error(&self, expr_struct_path: TokenStream) -> TokenStream {
-        type CommaPunctuated<T> = Punctuated<T, Token![,]>;
+    fn find_source_field(&self) -> usize {
+        for (i, field) in self.fields.iter().enumerate() {
+            if field.attrs.source.is_some() {
+                return i;
+            }
+        }
+        for (i, field) in self.fields.iter().enumerate() {
+            match &field.original.ident {
+                Some(ident) if ident == "source" => {
+                    return i;
+                }
+                _ => (),
+            }
+        }
+        self.fields.len()
+    }
 
-        let mut source_field_index = find_source_field(self.fields);
-        let source_field = self.fields.get(source_field_index);
-        let mut context_generics = CommaPunctuated::new();
-        let mut context_generic_defaults = CommaPunctuated::new();
-        let mut context_generic_bounds = CommaPunctuated::new();
-        let mut context_struct_fields = CommaPunctuated::new();
-        let mut expr_struct_fields = CommaPunctuated::new();
+    fn impl_all(self) -> TokenStream {
+        // Analyze feilds of contexts.
+        let context_vis = self.options.visibility.unwrap_or(&self.input.vis);
+        let mut source_field_index = self.find_source_field();
+        let mut source_ty = None;
+        let mut fields_analyzer = FieldsAnalyzer::default();
+        let mut generics_analyzer = GenericsAnalyzer::from_syn(&self.input.generics);
         let mut index = 0;
-        for field in self.fields.iter() {
+        for field in self.fields {
+            let original_ty = &field.original.ty;
+            let field_name = field
+                .original
+                .ident
+                .as_ref()
+                .map(FieldName::Named)
+                .unwrap_or_else(|| FieldName::Unnamed(index.into()));
+            let field_ty;
+            // Check if it's a source field.
             if index == source_field_index {
-                // Make `source_field_index` unreachable.
+                // Make index of source field unreachable.
                 source_field_index = self.fields.len();
-                if let Some(ident) = &field.original.ident {
-                    expr_struct_fields.push(quote!(#ident: source));
-                } else {
-                    expr_struct_fields.push(quote!(source));
-                }
+                source_ty = Some(original_ty);
+                field_ty = FieldType::Source;
             } else {
-                let generic = format_ident!("T{index}");
-                let field_attr = quote_attr(field.attrs.thisctx.attr.iter());
-                let field_vis = field.attrs.thisctx.visibility.as_ref().unwrap_or(self.vis);
-                if let Some(ident) = &field.original.ident {
-                    context_struct_fields.push(quote!(#field_attr #field_vis #ident: #generic));
-                    expr_struct_fields.push(quote!(#ident: self.#ident.into()));
+                let mut found = false;
+                // Check if type of the field intersects with input generics.
+                generics_analyzer.intersects(original_ty, |_, bounds| {
+                    found = true;
+                    bounds.context.selected = true;
+                });
+                field_ty = if found {
+                    FieldType::Original(original_ty)
                 } else {
-                    let member = Member::Unnamed(index.into());
-                    context_struct_fields.push(quote!(#field_attr #field_vis #generic));
-                    expr_struct_fields.push(quote!(self.#member.into()));
-                }
-                let field_ty = &field.original.ty;
-                context_generic_defaults.push(quote!(#generic = #field_ty));
-                context_generic_bounds.push(quote!(#generic: ::core::convert::Into<#field_ty>));
-                context_generics.push(generic);
+                    // Generate a new type for conversion.
+                    FieldType::Generated(format_ident!("__T{index}"), original_ty)
+                };
+                // Increase index.
                 index += 1;
             }
-        }
-        let context_struct_body;
-        let expr_struct_body;
-        let should_context_unit_body =
-            context_struct_fields.is_empty() && !matches!(self.unit, Some(false));
-        match self.original_fields {
-            Fields::Named(_) => {
-                context_struct_body = if should_context_unit_body {
-                    quote!(;)
-                } else {
-                    quote!({ #context_struct_fields })
-                };
-                expr_struct_body = quote!({ #expr_struct_fields });
-            }
-            Fields::Unnamed(_) => {
-                context_struct_body = if should_context_unit_body {
-                    quote!(;)
-                } else {
-                    quote!(( #context_struct_fields );)
-                };
-                expr_struct_body = quote!(( #expr_struct_fields ));
-            }
-            Fields::Unit => {
-                context_struct_body = quote!(;);
-                expr_struct_body = quote!();
-            }
+            fields_analyzer.push((
+                field_name,
+                FieldInfo {
+                    visibility: field
+                        .attrs
+                        .thisctx
+                        .visibility
+                        .as_ref()
+                        .unwrap_or(context_vis),
+                    attrs: &field.attrs,
+                    ty: field_ty,
+                },
+            ))
         }
 
-        let context_attr = self.attr;
-        let context_vis = self.vis;
-        let context_ty = match self.suffix {
-            Some(Suffix::Flag(flag)) if !flag => self.ident.clone(),
-            Some(Suffix::Ident(suff)) => {
-                format_ident!("{}{}", self.ident, suff, span = self.ident.span())
+        // Generate quote wrappers.
+        let context_definition_generics =
+            QuoteContextDefinitionGenerics(&generics_analyzer, &fields_analyzer);
+        let context_generics = QuoteContextGenerics(&generics_analyzer, &fields_analyzer);
+        let context_fields = QuoteContextFields(&fields_analyzer);
+        let constructor_generics = QuoteConstructorGenerics(&generics_analyzer);
+        let constructor_fields = QuoteConstructorFeilds(&fields_analyzer);
+        let impl_generics = QuoteImplGenerics(&generics_analyzer, &fields_analyzer);
+        let impl_bounds = QuoteImplBounds(&generics_analyzer, &fields_analyzer);
+
+        // Surround fields.
+        let context_definition_body = (
+            // Generate a unit body;
+            if index == 0 && !matches!(self.options.unit, Some(false)) {
+                Surround::None
+            } else {
+                self.surround
             }
-            _ => format_ident!("{}{}", self.ident, DEFAULT_SUFFIX, span = self.ident.span()),
+        )
+        .quote(context_fields, true);
+        let constructor_body = self.surround.quote(constructor_fields, false);
+
+        // Generate type of error.
+        let constructor_ident = &self.input.ident;
+        let error_ty = self
+            .options
+            .into
+            .map(QuoteMultiTypes::Variant1)
+            .unwrap_or_else(|| {
+                QuoteMultiTypes::Variant2(quote!(#constructor_ident::<#constructor_generics>))
+            });
+
+        // Generate type of context.
+        let context_ty = {
+            let ident = self.ident;
+            let span = self.ident.span();
+            match self.options.suffix {
+                Some(Suffix::Flag(false)) => QuoteMultiTypes::Variant1(self.ident),
+                Some(Suffix::Flag(true)) | None => {
+                    QuoteMultiTypes::Variant2(format_ident!("{ident}{DEFAULT_SUFFIX}", span = span))
+                }
+                Some(Suffix::Ident(suffix)) => {
+                    QuoteMultiTypes::Variant2(format_ident!("{ident}{suffix}", span = span))
+                }
+            }
         };
 
-        let error_ty = self.error;
-        let source_ty;
-        let impl_from_context_for_error;
-        if let Some(field) = source_field {
-            source_ty = field.original.ty.to_token_stream();
-            impl_from_context_for_error = None;
-        } else {
-            source_ty = quote!(());
-            impl_from_context_for_error = Some(quote!(
-                impl<#context_generics> From<#context_ty<#context_generics>> for #error_ty
-                where #context_generic_bounds
-                {
+        // Generate `impl From for Error`.
+        let impl_from_for_error = if source_ty.is_none() {
+            Some(quote!(
+                impl<#impl_generics>
+                ::core::convert::From<#context_ty<#context_generics>>
+                for #error_ty
+                where #impl_bounds {
                     #[inline]
                     fn from(context: #context_ty<#context_generics>) -> Self {
                         ::thisctx::IntoError::into_error(context, ())
                     }
                 }
-            ));
-        }
+            ))
+        } else {
+            None
+        };
 
+        // Generate definiton of context and impl `IntoError` for it.
+        let source_ty = QuoteSourceType(source_ty);
+        let context_attr = &self.options.attr;
+        let constructor_type_variant = self.variant.map(QuoteWithColon2);
         quote!(
-            #context_attr
-            #context_vis struct #context_ty<#context_generic_defaults>
-            #context_struct_body
+            #context_attr #context_vis
+            struct #context_ty<#context_definition_generics>
+            #context_definition_body
 
-            impl<#context_generics> ::thisctx::IntoError for #context_ty<#context_generics>
-            where #context_generic_bounds
-            {
+            impl<#impl_generics> ::thisctx::IntoError
+            for #context_ty<#context_generics>
+            where #impl_bounds {
                 type Error = #error_ty;
                 type Source = #source_ty;
 
                 #[inline]
                 fn into_error(self, source: #source_ty) -> #error_ty {
-                    #[allow(clippy::useless_conversion)]
-                    <#error_ty as ::core::convert::From<_>>::from(
-                        #expr_struct_path #expr_struct_body
+                    ::core::convert::From::from(
+                        #constructor_ident #constructor_type_variant
+                        #constructor_body
                     )
                 }
             }
 
-            #impl_from_context_for_error
+            #impl_from_for_error
         )
+    }
+}
+
+type FieldsAnalyzer<'a> = Vec<(FieldName<'a>, FieldInfo<'a>)>;
+
+enum FieldName<'a> {
+    Named(&'a Ident),
+    Unnamed(Index),
+}
+
+impl ToTokens for FieldName<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Named(t) => t.to_tokens(tokens),
+            Self::Unnamed(t) => t.to_tokens(tokens),
+        }
+    }
+}
+
+struct FieldInfo<'a> {
+    visibility: &'a Visibility,
+    attrs: &'a Attrs<'a>,
+    ty: FieldType<'a>,
+}
+
+enum FieldType<'a> {
+    Generated(Ident, &'a Type),
+    Original(&'a Type),
+    Source,
+}
+
+#[derive(Clone, Copy)]
+enum Surround {
+    Paren,
+    Brace,
+    None,
+}
+
+impl Surround {
+    fn from_fields(fields: &Fields) -> Self {
+        match fields {
+            Fields::Named(_) => Self::Brace,
+            Fields::Unnamed(_) => Self::Paren,
+            Fields::Unit => Self::None,
+        }
+    }
+
+    fn quote<T>(&self, content: T, semi: bool) -> QuoteSurround<T> {
+        QuoteSurround {
+            surround: *self,
+            content,
+            semi: if semi { Some(<_>::default()) } else { None },
+        }
+    }
+}
+
+struct QuoteImplGenerics<'a>(&'a GenericsAnalyzer<'a>, &'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteImplGenerics<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, bounds) in self.0.bounds.iter() {
+            let definition = QuoteGenericDefinition(name, bounds);
+            quote_extend!(tokens=> #definition,);
+        }
+        QuoteGeneratedGenerics(self.1).to_tokens(tokens);
+    }
+}
+
+struct QuoteImplBounds<'a>(&'a GenericsAnalyzer<'a>, &'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteImplBounds<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, bounds) in self.0.bounds.iter() {
+            if !bounds.params.is_empty() {
+                let params = bounds.params.iter();
+                quote_extend!(tokens=> #name: #(#params +)*,);
+            }
+        }
+        for bounds in self.0.extra_bounds.iter() {
+            quote_extend!(tokens=> #bounds,);
+        }
+        for (_, info) in self.1.iter() {
+            if let FieldType::Generated(ty, original) = &info.ty {
+                quote_extend!(tokens=> #ty: ::core::convert::Into<#original>,);
+            }
+        }
+    }
+}
+
+struct QuoteConstructorGenerics<'a>(&'a GenericsAnalyzer<'a>);
+impl ToTokens for QuoteConstructorGenerics<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, _) in self.0.bounds.iter() {
+            quote_extend!(tokens=> #name,);
+        }
+    }
+}
+
+struct QuoteContextDefinitionGenerics<'a>(&'a GenericsAnalyzer<'a>, &'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteContextDefinitionGenerics<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        QuoteSelectedGenericDefinitions(self.0).to_tokens(tokens);
+        for (_, info) in self.1 {
+            if let FieldType::Generated(ty, original) = &info.ty {
+                quote_extend!(tokens=> #ty = #original,);
+            }
+        }
+    }
+}
+
+struct QuoteContextGenerics<'a>(&'a GenericsAnalyzer<'a>, &'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteContextGenerics<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, bounds) in self.0.bounds.iter() {
+            if bounds.context.selected {
+                quote_extend!(tokens=> #name,);
+            }
+        }
+        QuoteGeneratedGenerics(self.1).to_tokens(tokens);
+    }
+}
+
+struct QuoteContextFields<'a>(&'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteContextFields<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, info) in self.0 {
+            if let FieldType::Source = info.ty {
+                continue;
+            }
+            QuoteAttrs(&info.attrs.thisctx.attr).to_tokens(tokens);
+            info.visibility.to_tokens(tokens);
+            if let FieldName::Named(name) = name {
+                quote_extend!(tokens=> #name:);
+            }
+            match &info.ty {
+                FieldType::Original(ty) => ty.to_tokens(tokens),
+                FieldType::Generated(ty, _) => ty.to_tokens(tokens),
+                FieldType::Source => unreachable!(),
+            }
+            quote_extend!(tokens=> ,);
+        }
+    }
+}
+
+struct QuoteConstructorFeilds<'a>(&'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteConstructorFeilds<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, info) in self.0 {
+            if let FieldName::Named(name) = name {
+                quote_extend!(tokens=> #name:);
+            }
+            match &info.ty {
+                FieldType::Original(_) => quote_extend!(tokens=> self.#name),
+                FieldType::Generated(..) => {
+                    quote_extend!(tokens=> ::core::convert::Into::into(self.#name));
+                }
+                FieldType::Source => quote_extend!(tokens=> source),
+            }
+            quote_extend!(tokens=> ,);
+        }
+    }
+}
+
+struct QuoteGeneratedGenerics<'a>(&'a FieldsAnalyzer<'a>);
+impl ToTokens for QuoteGeneratedGenerics<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (_, info) in self.0 {
+            if let FieldType::Generated(ty, _) = &info.ty {
+                quote_extend!(tokens=> #ty,);
+            }
+        }
+    }
+}
+
+struct QuoteSelectedGenericDefinitions<'a>(&'a GenericsAnalyzer<'a>);
+impl ToTokens for QuoteSelectedGenericDefinitions<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for (name, bounds) in self.0.bounds.iter() {
+            if bounds.context.selected {
+                let definition = QuoteGenericDefinition(name, bounds);
+                quote_extend!(tokens=> #definition,);
+            }
+        }
+    }
+}
+
+struct QuoteGenericDefinition<'a>(GenericName<'a>, &'a GenericBounds<'a>);
+impl ToTokens for QuoteGenericDefinition<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let Self(name, bounds) = self;
+        if let Some(kst_ty) = bounds.const_ty {
+            quote_extend!(tokens=> const #name: #kst_ty);
+        } else {
+            quote_extend!(tokens=> #name);
+        }
+    }
+}
+
+struct QuoteAttrs<'a>(&'a [TokenStream]);
+impl ToTokens for QuoteAttrs<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for args in self.0 {
+            quote_extend!(tokens=> #[#args]);
+        }
+    }
+}
+
+struct QuoteWithColon2<T>(T);
+impl<T: ToTokens> ToTokens for QuoteWithColon2<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let content = &self.0;
+        quote_extend!(tokens=> ::#content);
+    }
+}
+
+enum QuoteMultiTypes<T1 = TokenStream, T2 = TokenStream> {
+    Variant1(T1),
+    Variant2(T2),
+}
+impl<T1: ToTokens, T2: ToTokens> ToTokens for QuoteMultiTypes<T1, T2> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            QuoteMultiTypes::Variant1(t) => t.to_tokens(tokens),
+            QuoteMultiTypes::Variant2(t) => t.to_tokens(tokens),
+        }
+    }
+}
+
+struct QuoteSurround<T> {
+    surround: Surround,
+    content: T,
+    semi: Option<Token![;]>,
+}
+impl<T: ToTokens> ToTokens for QuoteSurround<T> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let content = &self.content;
+        let semi = &self.semi;
+        match self.surround {
+            Surround::Brace => quote_extend!(tokens=> {#content}),
+            Surround::Paren => quote_extend!(tokens=> (#content) #semi),
+            Surround::None => semi.to_tokens(tokens),
+        }
+    }
+}
+
+struct QuoteSourceType<'a>(Option<&'a Type>);
+impl ToTokens for QuoteSourceType<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(ty) = self.0 {
+            ty.to_tokens(tokens);
+        } else {
+            token::Paren::default().surround(tokens, |_| ());
+        }
+    }
+}
+
+impl ToTokens for GenericName<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Ident(t) => t.to_tokens(tokens),
+            Self::Lifetime(t) => t.to_tokens(tokens),
+        }
+    }
+}
+
+impl ToTokens for TypeParamBound<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Trait(t) => t.to_tokens(tokens),
+            Self::Lifetime(t) => t.to_tokens(tokens),
+        }
     }
 }

--- a/impl/src/generics.rs
+++ b/impl/src/generics.rs
@@ -1,0 +1,257 @@
+use std::collections::{btree_map::Entry as MapEntry, BTreeMap as Map};
+use syn::{
+    GenericArgument, GenericParam, Generics, Ident, Lifetime, PathArguments, TraitBound, Type,
+    WherePredicate,
+};
+
+pub struct GenericsAnalyzer<'a, C> {
+    pub bounds: GenericsMap<'a, C>,
+    pub extra_bounds: Vec<&'a WherePredicate>,
+}
+
+impl<C> Default for GenericsAnalyzer<'_, C> {
+    fn default() -> Self {
+        Self {
+            bounds: <_>::default(),
+            extra_bounds: <_>::default(),
+        }
+    }
+}
+
+pub struct GenericsMap<'a, C> {
+    indices: Map<GenericName<'a>, usize>,
+    entries: Vec<(GenericName<'a>, GenericBounds<'a, C>)>,
+}
+
+impl<C> Default for GenericsMap<'_, C> {
+    fn default() -> Self {
+        Self {
+            indices: <_>::default(),
+            entries: <_>::default(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub enum GenericName<'a> {
+    Ident(&'a Ident),
+    Lifetime(&'a Lifetime),
+}
+
+impl<'a> From<&'a Ident> for GenericName<'a> {
+    fn from(t: &'a Ident) -> Self {
+        Self::Ident(t)
+    }
+}
+
+impl<'a> From<&'a Lifetime> for GenericName<'a> {
+    fn from(t: &'a Lifetime) -> Self {
+        Self::Lifetime(t)
+    }
+}
+
+#[derive(Default)]
+pub struct GenericBounds<'a, C> {
+    pub params: Vec<TypeParamBound<'a>>,
+    pub const_ty: Option<&'a Type>,
+    pub context: C,
+}
+
+#[derive(Clone, Copy)]
+pub enum TypeParamBound<'a> {
+    Trait(&'a TraitBound),
+    Lifetime(&'a Lifetime),
+}
+
+impl<'a> From<&'a TraitBound> for TypeParamBound<'a> {
+    fn from(t: &'a TraitBound) -> Self {
+        Self::Trait(t)
+    }
+}
+
+impl<'a> From<&'a Lifetime> for TypeParamBound<'a> {
+    fn from(t: &'a Lifetime) -> Self {
+        Self::Lifetime(t)
+    }
+}
+
+impl<'a> From<&'a syn::TypeParamBound> for TypeParamBound<'a> {
+    fn from(t: &'a syn::TypeParamBound) -> Self {
+        match t {
+            syn::TypeParamBound::Trait(t) => Self::Trait(t),
+            syn::TypeParamBound::Lifetime(t) => Self::Lifetime(t),
+        }
+    }
+}
+
+impl<'a, C> GenericsAnalyzer<'a, C> {
+    pub fn intersects(
+        &mut self,
+        ty: &'a Type,
+        mut cb: impl FnMut(GenericName<'a>, &mut GenericBounds<'a, C>),
+    ) {
+        self.intersects_impl(ty, &mut cb);
+    }
+
+    fn intersects_impl(
+        &mut self,
+        ty: &'a Type,
+        cb: &mut impl FnMut(GenericName<'a>, &mut GenericBounds<'a, C>),
+    ) {
+        match ty {
+            Type::Path(ty) => {
+                if ty.qself.is_none() {
+                    if let Some(ident) = ty.path.get_ident() {
+                        self.intersects_callback(ident, &mut *cb);
+                    }
+                }
+                for segment in ty.path.segments.iter() {
+                    if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                        for arg in arguments.args.iter() {
+                            match arg {
+                                GenericArgument::Type(ty) => self.intersects_impl(ty, cb),
+                                GenericArgument::Lifetime(lt) => {
+                                    self.intersects_callback(lt, &mut *cb);
+                                }
+                                _ => (),
+                            }
+                        }
+                    }
+                }
+            }
+            Type::Reference(ty) => {
+                if let Some(lt) = ty.lifetime.as_ref() {
+                    self.intersects_callback(lt, &mut *cb);
+                }
+                self.intersects_impl(&ty.elem, cb);
+            }
+            _ => (),
+        }
+    }
+
+    fn intersects_callback(
+        &mut self,
+        name: impl Into<GenericName<'a>>,
+        cb: impl FnOnce(GenericName<'a>, &mut GenericBounds<'a, C>),
+    ) {
+        if let Some((key, bounds)) = self.bounds.get_mut(name) {
+            cb(key, bounds);
+        }
+    }
+
+    pub fn from_syn(generics: &'a Generics) -> Self
+    where
+        C: Default,
+    {
+        let mut new = Self::default();
+        // Collect bounds from type parameter.
+        for param in generics.params.iter() {
+            match param {
+                GenericParam::Type(ty) => new.update_params(&ty.ident, ty.bounds.iter()),
+                GenericParam::Lifetime(lt) => new.update_params(&lt.lifetime, lt.bounds.iter()),
+                GenericParam::Const(kst) => {
+                    new.bounds.insert_or_default(&kst.ident).const_ty = Some(&kst.ty)
+                }
+            }
+        }
+        // Collect bounds from where clause.
+        if let Some(clause) = generics.where_clause.as_ref() {
+            for predicate in clause.predicates.iter() {
+                match predicate {
+                    WherePredicate::Type(ty) => match &ty.bounded_ty {
+                        Type::Path(path) if path.qself.is_none() => {
+                            if let Some(ident) = path.path.get_ident() {
+                                new.update_clause(ident, ty.bounds.iter(), predicate);
+                            } else {
+                                new.extra_bounds.push(predicate);
+                            }
+                        }
+                        _ => new.extra_bounds.push(predicate),
+                    },
+                    WherePredicate::Lifetime(lt) => {
+                        new.update_clause(&lt.lifetime, lt.bounds.iter(), predicate);
+                    }
+                    WherePredicate::Eq(_) => new.extra_bounds.push(predicate),
+                }
+            }
+        }
+        new
+    }
+
+    fn update_clause<N, T>(
+        &mut self,
+        name: N,
+        bounds: impl Iterator<Item = T>,
+        predicate: &'a WherePredicate,
+    ) where
+        N: Into<GenericName<'a>>,
+        T: Into<TypeParamBound<'a>>,
+        C: Default,
+    {
+        match self.bounds.indices.entry(name.into()) {
+            MapEntry::Vacant(_) => self.extra_bounds.push(predicate),
+            MapEntry::Occupied(v) => self
+                .bounds
+                .entries
+                .get_mut(*v.get())
+                .unwrap_or_else(|| unreachable!())
+                .1
+                .params
+                .extend(bounds.map(T::into)),
+        }
+    }
+
+    fn update_params<N, T>(&mut self, name: N, bounds: impl Iterator<Item = T>)
+    where
+        N: Into<GenericName<'a>>,
+        T: Into<TypeParamBound<'a>>,
+        C: Default,
+    {
+        self.bounds
+            .insert_or_default(name.into())
+            .params
+            .extend(bounds.map(T::into));
+    }
+}
+
+impl<'a, C> GenericsMap<'a, C> {
+    pub fn iter(&self) -> impl Iterator<Item = (GenericName<'a>, &GenericBounds<'a, C>)> {
+        self.entries.iter().map(|(name, bounds)| (*name, bounds))
+    }
+
+    fn insert_or_default<N>(&mut self, name: N) -> &mut GenericBounds<'a, C>
+    where
+        N: Into<GenericName<'a>>,
+        C: Default,
+    {
+        let name = name.into();
+        let index;
+        match self.indices.entry(name) {
+            MapEntry::Occupied(v) => index = *v.get(),
+            MapEntry::Vacant(_) => {
+                index = self.entries.len();
+                self.indices.insert(name, index);
+                self.entries.push((name, <_>::default()));
+            }
+        };
+        &mut self
+            .entries
+            .get_mut(index)
+            .unwrap_or_else(|| unreachable!())
+            .1
+    }
+
+    pub fn get_mut<N>(&mut self, name: N) -> Option<(GenericName<'a>, &mut GenericBounds<'a, C>)>
+    where
+        N: Into<GenericName<'a>>,
+    {
+        self.indices
+            .get(&name.into())
+            .map(|index| {
+                self.entries
+                    .get_mut(*index)
+                    .unwrap_or_else(|| unreachable!())
+            })
+            .map(|(name, bounds)| (*name, bounds))
+    }
+}

--- a/impl/src/lib.rs
+++ b/impl/src/lib.rs
@@ -3,6 +3,7 @@
 mod ast;
 mod attr;
 mod expand;
+mod generics;
 
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};

--- a/tests/attr.rs
+++ b/tests/attr.rs
@@ -14,7 +14,7 @@ pub enum Error {
 fn requires_copied<T: Copy>(_: T) {}
 
 #[test]
-fn copy_context() {
+fn attr() {
     let ctx = ExtendAttributesContext("What's going on?");
     requires_copied(ctx);
 }

--- a/tests/derive_enum.rs
+++ b/tests/derive_enum.rs
@@ -37,7 +37,7 @@ fn ok() -> Result<(), BoxError> {
 }
 
 #[test]
-fn with_context() {
+fn derive_enum() {
     ok().context(NamedWithSourceContext {
         context_1: "",
         context_2: 0,

--- a/tests/derive_struct.rs
+++ b/tests/derive_struct.rs
@@ -52,7 +52,7 @@ fn ok() -> Result<(), BoxError> {
 }
 
 #[test]
-fn with_context() {
+fn derive_struct() {
     ok().context(NamedWithSourceContext {
         context_1: "",
         context_2: 0,

--- a/tests/enum_generics.rs
+++ b/tests/enum_generics.rs
@@ -39,3 +39,9 @@ enum UnusedGeneric<T1, T2> {
     Variant11(T1),
     Variant12(T2),
 }
+
+#[derive(WithContext)]
+enum ConstGeneric<const N1: usize, const N2: usize> {
+    Variant13([String; N1]),
+    Variant14([String; N2]),
+}

--- a/tests/enum_generics.rs
+++ b/tests/enum_generics.rs
@@ -1,0 +1,35 @@
+use thisctx::WithContext;
+
+#[derive(WithContext)]
+enum EmptyGeneric<T1, T2> {
+    Variant1(T1, T2),
+    Variant2(T1, String, T2),
+}
+
+#[derive(WithContext)]
+enum EmptyLifetime<'a, 'b> {
+    Variant3(&'a str, &'b str),
+    Variant4(&'a str, String, &'b str),
+}
+
+#[derive(WithContext)]
+enum BoundedGeneric<T1: Into<String>, T2>
+where
+    T2: Into<String>,
+    String: Into<String>,
+{
+    Variant5(T1, T2),
+    Variant6(T1, String, T2),
+}
+
+#[derive(WithContext)]
+enum BoundedLifetime<'a, 'b: 'a> {
+    Variant7(&'a str, &'b str),
+    Variant8(&'a str, String, &'b str),
+}
+
+// #[derive(WithContext)]
+// enum UnusedLifetime<'a, 'b> {
+//     Variant9(&'a str),
+//     Variant10(&'b [u8]),
+// }

--- a/tests/enum_generics.rs
+++ b/tests/enum_generics.rs
@@ -28,8 +28,14 @@ enum BoundedLifetime<'a, 'b: 'a> {
     Variant8(&'a str, String, &'b str),
 }
 
-// #[derive(WithContext)]
-// enum UnusedLifetime<'a, 'b> {
-//     Variant9(&'a str),
-//     Variant10(&'b [u8]),
-// }
+#[derive(WithContext)]
+enum UnusedLifetime<'a, 'b> {
+    Variant9(&'a str),
+    Variant10(&'b [u8]),
+}
+
+#[derive(WithContext)]
+enum UnusedGeneric<T1, T2> {
+    Variant11(T1),
+    Variant12(T2),
+}

--- a/tests/enum_into.rs
+++ b/tests/enum_into.rs
@@ -15,14 +15,14 @@ enum Error2 {
 
 #[derive(Debug, Error, WithContext)]
 #[thisctx(into(Error))]
-#[thisctx(into(Error2))]
 enum TransparentEnum {
     #[error("{0}")]
+    #[thisctx(into(Error2))]
     Whatever(String),
 }
 
 #[test]
-fn with_context() {
+fn enum_into() {
     let _: Error = ().context(WhateverContext("whatever")).unwrap_err();
     let _: Error2 = ().context(WhateverContext("whatever")).unwrap_err();
 }

--- a/tests/enum_into.rs
+++ b/tests/enum_into.rs
@@ -8,15 +8,21 @@ enum Error {
 }
 
 #[derive(Debug, Error, WithContext)]
+enum Error2 {
+    #[error(transparent)]
+    Transparent2(#[from] TransparentEnum),
+}
+
+#[derive(Debug, Error, WithContext)]
 #[thisctx(into(Error))]
+#[thisctx(into(Error2))]
 enum TransparentEnum {
     #[error("{0}")]
     Whatever(String),
 }
 
-fn requires_error(_: Error) {}
-
 #[test]
 fn with_context() {
-    requires_error(().context(WhateverContext("whatever")).unwrap_err());
+    let _: Error = ().context(WhateverContext("whatever")).unwrap_err();
+    let _: Error2 = ().context(WhateverContext("whatever")).unwrap_err();
 }

--- a/tests/from_context.rs
+++ b/tests/from_context.rs
@@ -9,7 +9,7 @@ enum Error {
 fn requires_error(_: Error) {}
 
 #[test]
-fn into_error() {
+fn from_context() {
     requires_error(ErrorFromContextContext("").into());
     requires_error(ErrorFromContextContext("").into_error(()));
     requires_error(IntoErrorContext.into_error("".to_owned()));

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -45,3 +45,15 @@ enum ConstGeneric<const N1: usize, const N2: usize> {
     Variant13([String; N1]),
     Variant14([String; N2]),
 }
+
+#[derive(WithContext)]
+struct GenricOrder<T1, T2>(T2, T1);
+
+#[derive(WithContext)]
+struct GenericDefault<T1, T2>(T1, String, T2);
+
+#[test]
+fn generic_order() {
+    let _ = GenricOrderContext::<String, i32>(0, String::default());
+    let _ = GenericDefaultContext::<i32, ()>(0, String::default(), ());
+}

--- a/tests/struct_into.rs
+++ b/tests/struct_into.rs
@@ -8,18 +8,21 @@ enum Error {
 }
 
 #[derive(Debug, Error, WithContext)]
+enum Error2 {
+    #[error(transparent)]
+    Transparent2(#[from] TransparentStruct),
+}
+
+#[derive(Debug, Error, WithContext)]
 #[thisctx(into(Error))]
+#[thisctx(into(Error2))]
 #[error("{reason}")]
 struct TransparentStruct {
     reason: String,
 }
 
-fn requires_error(_: Error) {}
-
 #[test]
 fn with_context() {
-    requires_error(
-        ().context(TransparentStructContext { reason: "whatever" })
-            .unwrap_err(),
-    );
+    let _: Error = ().context(TransparentStructContext { reason: "whatever" }).unwrap_err();
+    let _: Error2 = ().context(TransparentStructContext { reason: "whatever" }).unwrap_err();
 }

--- a/tests/struct_into.rs
+++ b/tests/struct_into.rs
@@ -22,7 +22,7 @@ struct TransparentStruct {
 }
 
 #[test]
-fn with_context() {
+fn struct_into() {
     let _: Error = ().context(TransparentStructContext { reason: "whatever" }).unwrap_err();
     let _: Error2 = ().context(TransparentStructContext { reason: "whatever" }).unwrap_err();
 }

--- a/tests/suffix.rs
+++ b/tests/suffix.rs
@@ -12,7 +12,7 @@ enum Error {
 }
 
 #[test]
-fn with_context() {
+fn suffix() {
     true.context(DefaultSuffixContext).unwrap();
     true.context(NoSuffix).unwrap();
     true.context(CustomSuffixThisctx).unwrap();

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -9,7 +9,7 @@ enum Error {
 }
 
 #[test]
-fn with_context() {
+fn unit() {
     true.context(NotUnitContext()).unwrap();
     true.context(UnitContext).unwrap();
 }

--- a/tests/visibility.rs
+++ b/tests/visibility.rs
@@ -13,7 +13,7 @@ mod error {
 }
 
 #[test]
-fn with_context() {
+fn visibility() {
     true.context(error::PubVariantContext(0)).unwrap();
     true.context(error::PubCrateVariantContext(0)).unwrap();
 }


### PR DESCRIPTION
Support generics in derive input types, in addition, `IntoError` allows convert context into multiple errors.

## Example

```rust
#[derive(WithContext)]
enum Error<T1, T2> {
    Variant1(T1, T2),
    Variant2(T1, String, T2),
}
```