### PR TITLE
feat(derive): auto unwrap `Option<T>`

### DIFF
--- a/packages/compile_tests/compile_tests/unwrap_type.rs
+++ b/packages/compile_tests/compile_tests/unwrap_type.rs
@@ -1,0 +1,14 @@
+use thisctx::{IntoError, WithContext};
+
+#[derive(WithContext)]
+pub struct UnwrapOption(Option<String>);
+
+#[derive(WithContext)]
+#[thisctx(no_unwrap)]
+pub struct NotUnwrapOption(Option<String>);
+
+fn main() {
+    UnwrapOptionContext(Some("optional")).build();
+    NotUnwrapOptionContext(Some("optional".to_owned())).build();
+    NotUnwrapOptionContext(Some("optional")).build();
+}

--- a/packages/compile_tests/compile_tests/unwrap_type.stderr
+++ b/packages/compile_tests/compile_tests/unwrap_type.stderr
@@ -1,0 +1,22 @@
+error[E0599]: the method `build` exists for struct `NotUnwrapOptionContext<Option<&str>>`, but its trait bounds were not satisfied
+  --> compile_tests/unwrap_type.rs:13:46
+   |
+6  | #[derive(WithContext)]
+   |          -----------
+   |          |
+   |          method `build` not found for this struct
+   |          doesn't satisfy `_: IntoError<NotUnwrapOption>`
+...
+13 |     NotUnwrapOptionContext(Some("optional")).build();
+   |                                              ^^^^^ method cannot be called on `NotUnwrapOptionContext<Option<&str>>` due to unsatisfied trait bounds
+   |
+  ::: $RUST/core/src/option.rs
+   |
+   | pub enum Option<T> {
+   | ------------------ doesn't satisfy `Option<&str>: Into<Option<String>>`
+   |
+note: trait bound `Option<&str>: Into<Option<String>>` was not satisfied
+  --> compile_tests/unwrap_type.rs:6:10
+   |
+6  | #[derive(WithContext)]
+   |          ^^^^^^^^^^^ unsatisfied trait bound introduced in this `derive` macro

--- a/packages/impl/src/attr.rs
+++ b/packages/impl/src/attr.rs
@@ -14,6 +14,7 @@ mod kw {
     custom_keyword!(module);
     custom_keyword!(no_generic);
     custom_keyword!(no_unit);
+    custom_keyword!(no_unwrap);
     custom_keyword!(skip);
     custom_keyword!(suffix);
     custom_keyword!(transparent);
@@ -34,6 +35,7 @@ pub struct AttrThisctx {
     pub module: Option<Ident>,
     pub no_generic: Option<bool>,
     pub no_unit: Option<bool>,
+    pub no_unwrap: Option<bool>,
     pub skip: Option<bool>,
     pub suffix: Option<Suffix>,
     pub visibility: Option<Visibility>,
@@ -139,6 +141,9 @@ fn parse_thisctx_attribute(attrs: &mut AttrThisctx, original: &Attribute) -> Res
             } else if lookhead.peek(kw::no_unit) {
                 check_dup!(no_unit);
                 attrs.no_unit = Some(parse_bool(input)?);
+            } else if lookhead.peek(kw::no_unwrap) {
+                check_dup!(no_unwrap);
+                attrs.no_unwrap = Some(parse_bool(input)?);
             } else if lookhead.peek(kw::skip) {
                 check_dup!(skip);
                 attrs.skip = Some(parse_bool(input)?);

--- a/tests/unwrap_type.rs
+++ b/tests/unwrap_type.rs
@@ -1,0 +1,14 @@
+use thisctx::{IntoError, WithContext};
+
+#[derive(WithContext)]
+pub struct UnwrapOption(Option<String>);
+
+#[derive(WithContext)]
+#[thisctx(no_unwrap)]
+pub struct NotUnwrapOption(Option<String>);
+
+#[test]
+fn optional() {
+    UnwrapOptionContext(Some("optional")).build();
+    NotUnwrapOptionContext(Some("optional".to_owned())).build();
+}


### PR DESCRIPTION
If the type of a field is `Option<T>`, the macro will try to use the inner type `T` to generate generics. This feature facilitates type conversion between `Option`s.

## Example

```rust
#[derive(WithContext)]
pub struct UnwrapOption(Option<String>);

#[derive(WithContext)]
#[thisctx(no_unwrap)]
pub struct NotUnwrapOption(Option<String>);

fn main() {
    UnwrapOptionContext(Some("optional")).build();
    // Option<&str> cannot be converted into Option<String> directly
    NotUnwrapOptionContext(Some("optional".to_owned())).build();
}
```